### PR TITLE
Refactor based on feedback

### DIFF
--- a/distanceapp/api/views.py
+++ b/distanceapp/api/views.py
@@ -15,8 +15,6 @@ from .serializers import AddressSerializer
 load_dotenv()
 
 GOOGLE_MAPS_API_KEY = os.environ.get('GOOGLE_MAPS_API_KEY')
-print(f"GOOGLE_MAPS_API_KEY: {GOOGLE_MAPS_API_KEY}")
-
 
 class AddressViewSet(viewsets.ModelViewSet):
     # TODO refactor to avoid using all() and opt for something more scalable
@@ -125,7 +123,6 @@ def get_place_details(request):
     if not place_id:
         return JsonResponse({'error': 'Place ID is required.'}, status=400)
 
-    # Fetch place details using the Google Places Details API
     details_url = "https://maps.googleapis.com/maps/api/place/details/json"
     details_params = {
         'place_id': place_id,

--- a/distanceapp/distanceapp-frontend/index.html
+++ b/distanceapp/distanceapp-frontend/index.html
@@ -5,11 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Distance App</title>
-    <script
-            async
-            defer
-            src="https://maps.googleapis.com/maps/api/js?key={GOOGLEAPIKEY}">
-    </script>
 </head>
 <body>
 <div id="app"></div>

--- a/distanceapp/distanceapp-frontend/src/App.vue
+++ b/distanceapp/distanceapp-frontend/src/App.vue
@@ -104,9 +104,7 @@ async function calculateDistance() {
         lng: destination.value.lng,
       },
     })
-    console.log('resp', resp);
     responseData.value = resp.data;
-    console.log('responseData', responseData.value);
   } catch (error) {
     console.error(error);
   }

--- a/distanceapp/distanceapp-frontend/src/App.vue
+++ b/distanceapp/distanceapp-frontend/src/App.vue
@@ -11,7 +11,8 @@
         <AutocompleteInput
             input-id="origin-input"
             placeholder="Enter origin address or landmark"
-            @placeSelected="setOrigin"
+            @place-selected="setOrigin"
+            @input-cleared="resetDistance"
             :country-restriction="{country: 'us'}"
         />
       </el-col>
@@ -19,7 +20,8 @@
         <AutocompleteInput
             input-id="destination-input"
             placeholder="Enter destination address or landmark"
-            @placeSelected="setDestination"
+            @place-selected="setDestination"
+            @input-cleared="resetDistance"
             :country-restriction="{country: 'us'}"
         />
       </el-col>
@@ -130,10 +132,6 @@ watch([origin, destination], () => {
 <style scoped>
 .centered-row {
   display: flex;
-  align-items: baseline;
-}
-
-.button {
-  margin-bottom: 10px;
+  align-items: center;
 }
 </style>

--- a/distanceapp/distanceapp-frontend/src/components/AutocompleteInput.vue
+++ b/distanceapp/distanceapp-frontend/src/components/AutocompleteInput.vue
@@ -44,15 +44,10 @@ async function fetchPlaces(query: string, callback: (suggestions: Place[]) => vo
   }
 
   try {
-    // Call the backend endpoint to fetch suggestions
     const response = await axios.get('http://127.0.0.1:8000/api/places-autocomplete/', {
       params: {query},
     });
 
-    console.log("response.data", response.data);
-
-
-    // Map the response to a format expected by el-autocomplete
     const places = response.data.predictions.map((place: Place) => ({
       value: place.description,
       place_id: place.place_id,

--- a/distanceapp/distanceapp-frontend/src/components/AutocompleteInput.vue
+++ b/distanceapp/distanceapp-frontend/src/components/AutocompleteInput.vue
@@ -1,20 +1,24 @@
 <template>
-  <div>
-    <el-input
-        v-model="inputValue"
-        :id="inputId"
-        type="text"
-        :placeholder="placeholder"
-        class="autocomplete-input"
-        ref="inputRef"
-    />
-  </div>
+  <el-autocomplete
+      v-model="inputValue"
+      :trigger-on-focus="false"
+      :placeholder="props.placeholder"
+      :fetch-suggestions="fetchPlaces"
+      @select="handleSelect"
+      :popper-class="props.inputId"
+      class="autocomplete-input"
+      clearable
+      @input="handleInputChange"
+  />
 </template>
 
 <script setup lang="ts">
-import {onMounted, ref} from 'vue';
+import {ref} from 'vue';
+import axios from 'axios';
 
-const emit = defineEmits(['placeSelected']);
+
+const emit = defineEmits(['placeSelected', 'inputCleared']);
+
 
 const props = defineProps<{
   inputId: string;
@@ -22,59 +26,71 @@ const props = defineProps<{
   countryRestriction: { country: string };
 }>();
 
-const inputRef = ref(null);
 const inputValue = ref('');
 
-function initializeAutocomplete() {
-  // NEVER CHANGE!!!! THIS NEEDS TO BE INPUT FOR THE PLACES API TO WORK!!!!!
-  const nativeInput = inputRef.value?.input as HTMLInputElement;
-
-  if (nativeInput) {
-    const autocomplete = new google.maps.places.Autocomplete(nativeInput, {
-      types: ['geocode', 'establishment'],
-      componentRestrictions: props.countryRestriction,
-    });
-
-    autocomplete.addListener('place_changed', () => {
-      const place = autocomplete.getPlace();
-
-      if (place.geometry) {
-        const formattedPlace = {
-          address: place.formatted_address || place.name,
-          lat: place?.geometry?.location?.lat(),
-          lng: place?.geometry?.location?.lng(),
-          name: place.name,
-          placeId: place.place_id,
-        };
-
-        emit('placeSelected', formattedPlace);
-      } else {
-        console.log('No details available for the input:', nativeInput.value);
-      }
-    });
-    nativeInput.addEventListener('input', handleInputChange);
-  }
-  // } else if (inputRef.value) {
-  //   console.error('Failed to access the native input element:', inputRef.value);
-  // }
+interface Place {
+  description: string;
+  place_id: string;
+  structured_formatting: {
+    main_text: string;
+    secondary_text: string;
+  };
 }
 
-function handleInputChange(event: Event) {
-  const target = event.target as HTMLInputElement;
-  inputValue.value = target.value;
+async function fetchPlaces(query: string, callback: (suggestions: Place[]) => void) {
+  if (!query) {
+    callback([]);
+    return;
+  }
 
-  if (!target.value) {
-    emit('placeSelected', {address: '', lat: 0, lng: 0, name: '', placeId: ''});
+  try {
+    // Call the backend endpoint to fetch suggestions
+    const response = await axios.get('http://127.0.0.1:8000/api/places-autocomplete/', {
+      params: {query},
+    });
+
+    console.log("response.data", response.data);
+
+
+    // Map the response to a format expected by el-autocomplete
+    const places = response.data.predictions.map((place: Place) => ({
+      value: place.description,
+      place_id: place.place_id,
+      structured_formatting: place.structured_formatting,
+    }));
+
+    // Update the suggestions using the callback
+    callback(places);
+  } catch (error) {
+    console.error('Error fetching places:', error);
+    callback([]);
   }
 }
 
-onMounted(() => {
-  if (window.google && window.google.maps && window.google.maps.places) {
-    initializeAutocomplete();
-  } else {
-    window.addEventListener('load', initializeAutocomplete);
+interface SelectedPlace {
+  place_id: string;
+}
+
+async function handleSelect(item: SelectedPlace) {
+  try {
+    // Fetch the selected place details including lat and lng
+    const response = await axios.get('http://127.0.0.1:8000/api/get-place-details/', {
+      params: {place_id: item.place_id},
+    });
+
+    // Emit the selected place details to the parent component
+    emit('placeSelected', response.data);
+  } catch (error) {
+    console.error('Error fetching place details:', error);
   }
-});
+}
+
+function handleInputChange(value: string) {
+  inputValue.value = value;
+  if (!value) {
+    emit('inputCleared', '');
+  }
+}
 
 </script>
 
@@ -82,7 +98,7 @@ onMounted(() => {
 .autocomplete-input {
   width: 100%;
   padding: 10px;
-  font-size: 16px;
+  font-size: 18px;
   border-radius: 4px;
   margin-bottom: 10px;
 }

--- a/distanceapp/distanceapp/urls.py
+++ b/distanceapp/distanceapp/urls.py
@@ -1,22 +1,7 @@
-"""distanceapp URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from api.views import AddressViewSet, calculate_distance
+from api.views import AddressViewSet, calculate_distance, google_places_autocomplete, get_place_details
 
 router = DefaultRouter()
 router.register(r'addresses', AddressViewSet)
@@ -24,5 +9,7 @@ router.register(r'addresses', AddressViewSet)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
+    path('api/get-place-details/', get_place_details, name='get_place_details'),
+    path('api/places-autocomplete/', google_places_autocomplete, name='places_autocomplete'),
     path('api/calculate-distance/', calculate_distance, name='calculate_distance'),
 ]

--- a/distanceapp/requirements.txt
+++ b/distanceapp/requirements.txt
@@ -5,3 +5,4 @@ djangorestframework==3.15.2
 psycopg2==2.9.9
 python-dotenv==1.0.1
 sqlparse==0.5.1
+requests==2.26.0


### PR DESCRIPTION
- Moved external API call to the backend, avoiding exposing secrets
- Two new routes: one for the autocomplete functionality, and the other for the place details which are necessary for calculating the distance between the addresses
- Cleaned up AutocompleteInput; using `el-autocomplete` and listening for events through props and emits instead of the needlessly verbose way I was doing it earlier